### PR TITLE
Refactor file helpers to use configurable FileSource and add ExtensionFactory 

### DIFF
--- a/src/main/java/fr/pinguet62/wiremock/files/FileContentHelper.java
+++ b/src/main/java/fr/pinguet62/wiremock/files/FileContentHelper.java
@@ -2,18 +2,27 @@ package fr.pinguet62.wiremock.files;
 
 import com.github.jknack.handlebars.Options;
 import com.github.tomakehurst.wiremock.common.FileSource;
-import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
 import com.github.tomakehurst.wiremock.common.TextFile;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.HandlebarsHelper;
 
-import java.io.File;
-
+/**
+ * Helper class which reads the contents of a file by given path.
+ * The path is resolved against the global configured {@link FileSource}
+ */
 public class FileContentHelper extends HandlebarsHelper<String> {
 
-    private final FileSource fileSource = new SingleRootFileSource(new File("/home/wiremock/__files"));
+    private final FileSource fileSource;
+
+    /**
+     * creates the helper using the given file source
+     * @param fileSource the {@link FileSource fileSource} to resolve paths against.
+     */
+    public FileContentHelper(FileSource fileSource) {
+        this.fileSource = fileSource;
+    }
 
     @Override
-    public String apply(String context, Options options) {
+    public Object apply(String context, Options options) {
         TextFile textFileNamed = fileSource.getTextFileNamed(context);
         return textFileNamed.readContentsAsString();
     }

--- a/src/main/java/fr/pinguet62/wiremock/files/FileExistsHelper.java
+++ b/src/main/java/fr/pinguet62/wiremock/files/FileExistsHelper.java
@@ -2,17 +2,27 @@ package fr.pinguet62.wiremock.files;
 
 import com.github.jknack.handlebars.Options;
 import com.github.tomakehurst.wiremock.common.FileSource;
-import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
 import com.github.tomakehurst.wiremock.extension.responsetemplating.helpers.HandlebarsHelper;
 
-import java.io.File;
-
+/**
+ * Helper class which checks if file exists ant given path.
+ * The path is resolved against the global configured {@link FileSource}
+ */
 public class FileExistsHelper extends HandlebarsHelper<String> {
 
-    private final FileSource fileSource = new SingleRootFileSource(new File("/home/wiremock/__files"));
+
+    private final FileSource fileSource;
+
+    /**
+     * creates the helper with the given file source
+     * @param fileSource the {@link FileSource source} to resolve paths against
+     */
+    public FileExistsHelper(FileSource fileSource) {
+        this.fileSource = fileSource;
+    }
 
     @Override
-    public Boolean apply(String context, Options options) {
+    public Object apply(String context, Options options) {
         return fileSource.child(context).exists();
     }
 }

--- a/src/main/java/fr/pinguet62/wiremock/files/FileExtensionFactory.java
+++ b/src/main/java/fr/pinguet62/wiremock/files/FileExtensionFactory.java
@@ -1,0 +1,18 @@
+package fr.pinguet62.wiremock.files;
+
+import com.github.tomakehurst.wiremock.extension.Extension;
+import com.github.tomakehurst.wiremock.extension.ExtensionFactory;
+import com.github.tomakehurst.wiremock.extension.WireMockServices;
+
+import java.util.List;
+
+/**
+ * the {@link ExtensionFactory factory} to create the Files extension
+ */
+public class FileExtensionFactory implements ExtensionFactory {
+
+    @Override
+    public List<Extension> create(WireMockServices services) {
+        return List.of(new FilesTemplateHelperProviderExtension(services.getFiles()));
+    }
+}

--- a/src/main/java/fr/pinguet62/wiremock/files/FilesTemplateHelperProviderExtension.java
+++ b/src/main/java/fr/pinguet62/wiremock/files/FilesTemplateHelperProviderExtension.java
@@ -1,11 +1,24 @@
 package fr.pinguet62.wiremock.files;
 
 import com.github.jknack.handlebars.Helper;
+import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.extension.TemplateHelperProviderExtension;
 
 import java.util.Map;
 
+/**
+ * a {@link TemplateHelperProviderExtension templateHelperExtension} which provides the helper for dealing the files
+ */
 public class FilesTemplateHelperProviderExtension implements TemplateHelperProviderExtension {
+
+    private final FileSource fileSource;
+
+    /**
+     * @param files the main {@link FileSource fileSource}
+     */
+    public FilesTemplateHelperProviderExtension(FileSource files) {
+        this.fileSource = files;
+    }
 
     @Override
     public String getName() {
@@ -15,7 +28,7 @@ public class FilesTemplateHelperProviderExtension implements TemplateHelperProvi
     @Override
     public Map<String, Helper<?>> provideTemplateHelpers() {
         return Map.ofEntries(
-            Map.entry("file-exists", new FileExistsHelper()),
-            Map.entry("file-content", new FileContentHelper()));
+            Map.entry("file-exists", new FileExistsHelper(fileSource)),
+            Map.entry("file-content", new FileContentHelper(fileSource)));
     }
 }

--- a/src/main/resources/META-INF/services/com.github.tomakehurst.wiremock.extension.Extension
+++ b/src/main/resources/META-INF/services/com.github.tomakehurst.wiremock.extension.Extension
@@ -1,1 +1,0 @@
-fr.pinguet62.wiremock.files.FilesTemplateHelperProviderExtension

--- a/src/main/resources/META-INF/services/com.github.tomakehurst.wiremock.extension.ExtensionFactory
+++ b/src/main/resources/META-INF/services/com.github.tomakehurst.wiremock.extension.ExtensionFactory
@@ -1,0 +1,1 @@
+fr.pinguet62.wiremock.files.FileExtensionFactory


### PR DESCRIPTION
changed logic to use the globally configured fileSource instead of a hardcoded value
update registration process to use the ExtensionFactory approach to inject the global filesource into the helpers 